### PR TITLE
Support key padding masks for Perceiver AR

### DIFF
--- a/docs/training-examples.md
+++ b/docs/training-examples.md
@@ -172,10 +172,10 @@ UTF-8 bytes of the input.
   python examples/training/clm/train.py
   ```
 
-For better generalization to shorter sequences I found random sequence truncation helpful which can be enabled with
-`--model.random_truncation=true`. The minimum sequence length can be configured with `--model.random_min_seq_lem=m`.
-Random sequence truncation randomly truncates sequences in a batch to length `randint(m, n+1)` where `m < n` and `n`
-is the configured `max_seq_len`.
+For better generalization to shorter sequences I found random sequence truncation at training time helpful. This can be
+enabled with `--data.random_train_truncation=true`. The minimum sequence length can be configured with `--data.random_min_seq_lem=m`.
+Random sequence truncation randomly truncates sequences in a batch to length `randint(m, n+1)` where `m < n` and `n` is
+the configured `max_seq_len`. Sequences are truncated from the right and padded to the left (`--data.padding_side=left`).
 
 With option `--model.validation_sample_record=-1` a sequence is randomly picked from the validation set and used as
 prompt for sequence generation during validation. The prompt and the generated sequence is logged to Tensorboard. You

--- a/examples/training/clm/prep.sh
+++ b/examples/training/clm/prep.sh
@@ -1,5 +1,6 @@
 python -m perceiver.scripts.text.preproc wikitext \
   --tokenizer=deepmind/language-perceiver \
+  --random_train_shift=true \
   --add_special_tokens=false \
   --max_seq_len=4096 \
   --task=clm

--- a/examples/training/clm/train.py
+++ b/examples/training/clm/train.py
@@ -26,6 +26,8 @@ data = WikiTextDataModule(
     max_seq_len=4096,
     batch_size=24,
     task=Task.clm,
+    padding_side="left",
+    random_train_shift=True,
 )
 
 config = CausalLanguageModelConfig(

--- a/examples/training/clm/train.sh
+++ b/examples/training/clm/train.sh
@@ -2,14 +2,14 @@ python -m perceiver.scripts.text.clm fit \
   --model.num_latents=512 \
   --model.cross_attention_dropout=0.5 \
   --model.post_attention_dropout=0.0 \
-  --model.random_truncation=false \
-  --model.random_min_seq_len=16 \
   --data=WikiTextDataModule \
   --data.tokenizer=deepmind/language-perceiver \
   --data.add_special_tokens=false \
   --data.max_seq_len=4096 \
   --data.task=clm \
   --data.batch_size=24 \
+  --data.padding_side=left \
+  --data.random_train_shift=true \
   --optimizer=Adam \
   --optimizer.lr=2e-4 \
   --lr_scheduler.warmup_steps=200 \

--- a/perceiver/model/text/common.py
+++ b/perceiver/model/text/common.py
@@ -13,6 +13,7 @@ from perceiver.model.core.convert import (
     copy_params,
     copy_self_attention_block_params,
 )
+from perceiver.model.core.position import positions
 from perceiver.model.core.utils import freeze, is_checkpoint
 
 
@@ -38,9 +39,10 @@ class TextInputAdapter(InputAdapter):
     def max_seq_len(self):
         return self.pos_embedding.num_embeddings
 
-    def forward(self, x):
-        positions = torch.arange(0, x.shape[1], device=x.device)
-        return self.txt_embedding(x) + self.pos_embedding(positions)
+    def forward(self, x, abs_pos=None):
+        if abs_pos is None:
+            abs_pos = positions(*x.shape, device=x.device)
+        return self.txt_embedding(x) + self.pos_embedding(abs_pos)
 
 
 class TextEncoder(PerceiverEncoder):

--- a/perceiver/scripts/text/clm.py
+++ b/perceiver/scripts/text/clm.py
@@ -18,8 +18,6 @@ class CausalLanguageModelCLI(CLI):
                 "model.num_self_attention_layers": 8,
                 "model.cross_attention_dropout": 0.5,
                 "model.post_attention_dropout": 0.0,
-                "model.random_truncation": False,
-                "model.random_min_seq_len": 16,
             }
         )
 

--- a/perceiver/scripts/text/preproc.py
+++ b/perceiver/scripts/text/preproc.py
@@ -39,5 +39,6 @@ if __name__ == "__main__":
     parser.add_argument("--mask_words", default=True, type=bool)
     parser.add_argument("--static_masking", default=False, type=bool)
     parser.add_argument("--add_special_tokens", default=False, type=bool)
+    parser.add_argument("--random_train_shift", default=False, type=bool)
     parser.add_argument("--preproc_workers", default=mp.cpu_count(), type=int)
     main(parser.parse_args())


### PR DESCRIPTION
- tokenizers must be configured to `padding_side="left"` in order to be compatible with Perceiver AR
- support configuration of `padding_side` on base class of text data modules (`TextDataModule`).
- implement random sequence truncation in data module instead of model
- sequences in a batch are individually truncated to different lengths.
- enable `random_train_shift` by default which increases regularization.