### PR TITLE
Fix activation checkpointing

### DIFF
--- a/examples/training/img_clf/train.py
+++ b/examples/training/img_clf/train.py
@@ -47,7 +47,6 @@ config = ImageClassifierConfig(
     num_latent_channels=128,
 )
 
-
 if __name__ == "__main__":
     lit_model = LitImageClassifier.create(config)
 
@@ -55,7 +54,7 @@ if __name__ == "__main__":
         accelerator="gpu",
         devices=2,
         max_epochs=30,
-        strategy=DDPStrategy(find_unused_parameters=False),
+        strategy=DDPStrategy(find_unused_parameters=False, static_graph=True),
         logger=TensorBoardLogger(save_dir="logs", name="img_clf"),
     )
 

--- a/examples/training/img_clf/train.sh
+++ b/examples/training/img_clf/train.sh
@@ -19,6 +19,7 @@ python -m perceiver.scripts.vision.image_classifier fit \
   --trainer.accelerator=gpu \
   --trainer.devices=2 \
   --trainer.max_epochs=30 \
+  --trainer.strategy=ddp_static_graph \
   --trainer.logger=TensorBoardLogger \
   --trainer.logger.save_dir=logs \
   --trainer.logger.name=img_clf


### PR DESCRIPTION
- Create new function `activation_checkpoint_wrapper` to convert module outputs to be compatible with fairscale activation checkpoint wrapper
- Use `static_graph` (see https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html) in img_clf training to allow training with activation checkpointing which otherwise fails with an error